### PR TITLE
Extension to also apply the default featured image to failed HTTP-loaded images

### DIFF
--- a/app/extension-remote-check.php
+++ b/app/extension-remote-check.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * An extension to the WordPress plugin "Default Featured Image" that uses the default featured image set for post
+ * featured images that can't be loaded via HTTPS. This option is non-render blocking.
+ *
+ * WARNING: This feature is a simple proof of concept and should be better integrated if you plan to use it in a
+ * production environment (e.g., checking for result in cache to avoid constant `fetch()` requests, even though
+ * they're non-render blocking).
+ *
+ * @return void
+ * @author Kolja Nolte <kolja.nolte@gmail.com>
+ */
+add_action(
+	'wp_head',
+	function (): void {
+		// Get the plugin's set default featured image ID from the WordPress options.
+		$default_featured_image_id = get_option( 'dfi_image_id' );
+
+		// If no default featured image ID is set, exit the function.
+		if ( ! $default_featured_image_id ) {
+			return;
+		}
+
+		// Get the URL and srcset of the default featured image.
+		$default_featured_image_url    = wp_get_attachment_url( $default_featured_image_id );
+		$default_featured_image_srcset = wp_get_attachment_image_srcset( $default_featured_image_id );
+		?>
+		<script>
+          /**
+           * Adds an event listener to the DOMContentLoaded event to wait until all default featured images are loaded.
+           */
+          document.addEventListener('DOMContentLoaded', function () {
+            // Select all images with the class 'wp-post-image'.
+            const images = document.querySelectorAll('img.wp-post-image')
+
+            // Store the default featured image URL and srcset.
+            const defaultFeaturedImage  = '<?php echo esc_js( $default_featured_image_url ); ?>'
+            const defaultFeaturedSrcset = '<?php echo esc_js( $default_featured_image_srcset ); ?>'
+
+            // Loop through each image.
+            for (const image of images) {
+              // If the image does not have the class 'default-featured-img', check its source.
+              if (!image.classList.contains('default-featured-img')) {
+                // Fetch the image source to check if it is valid.
+                fetch(image.getAttribute('src'), { method: 'HEAD' })
+                .then(response => {
+                  // If the response is not OK or the content type is not an image, set the default featured image.
+                  if (!response.ok || !response.headers.get('content-type').includes('image')) {
+                    image.setAttribute('src', defaultFeaturedImage)
+                    image.setAttribute('srcset', defaultFeaturedSrcset)
+                  }
+                })
+                .catch(error => {
+                  // Log any errors and set the default featured image.
+                  console.error('Error fetching image:', error)
+                })
+              }
+            }
+          })
+		</script>
+		<?php
+	}
+);

--- a/set-default-featured-image.php
+++ b/set-default-featured-image.php
@@ -14,51 +14,84 @@
  * @package DFI
  */
 
-define( 'DFI_VERSION', '1.7.3' );
-define( 'DFI_DIR', plugin_dir_path( __FILE__ ) );
-define( 'DFI_URL', plugin_dir_url( __FILE__ ) );
-define( 'DFI_NAME', basename( __DIR__ ) . DIRECTORY_SEPARATOR . basename( __FILE__ ) );
+define('DFI_VERSION', '1.7.3');
+define('DFI_DIR', plugin_dir_path(__FILE__));
+define('DFI_URL', plugin_dir_url(__FILE__));
+define(
+	'DFI_NAME',
+	basename(__DIR__) . DIRECTORY_SEPARATOR . basename(__FILE__)
+);
 
 require_once DFI_DIR . 'app' . DIRECTORY_SEPARATOR . 'class-dfi.php';
 require_once DFI_DIR . 'app' . DIRECTORY_SEPARATOR . 'class-dfi-exceptions.php';
 
+if (
+	is_file(DFI_DIR . 'app' . DIRECTORY_SEPARATOR . 'extension-remote-check.php')
+) {
+	require_once DFI_DIR .
+		'app' .
+		DIRECTORY_SEPARATOR .
+		'extension-remote-check.php';
+}
+
 $dfi = DFI::instance();
 
 // add the settings field to the media page.
-add_action( 'admin_init', array( $dfi, 'media_setting' ) );
+add_action('admin_init', [$dfi, 'media_setting']);
 // enqueue the js.
-add_action( 'admin_print_scripts-options-media.php', array( $dfi, 'admin_scripts' ) );
+add_action('admin_print_scripts-options-media.php', [$dfi, 'admin_scripts']);
 // get the preview image ajax call.
-add_action( 'wp_ajax_dfi_change_preview', array( $dfi, 'ajax_wrapper' ) );
+add_action('wp_ajax_dfi_change_preview', [$dfi, 'ajax_wrapper']);
 // set dfi meta key on every occasion.
-add_filter( 'get_post_metadata', array( $dfi, 'set_dfi_meta_key' ), 10, 4 );
+add_filter('get_post_metadata', [$dfi, 'set_dfi_meta_key'], 10, 4);
 // display a default featured image.
-add_filter( 'post_thumbnail_html', array( $dfi, 'show_dfi' ), 20, 5 );
+add_filter('post_thumbnail_html', [$dfi, 'show_dfi'], 20, 5);
 // add a link on the plugin page to the setting.
-add_filter( 'plugin_action_links_default-featured-image/set-default-featured-image.php', array( $dfi, 'add_settings_link' ) );
+add_filter(
+	'plugin_action_links_default-featured-image/set-default-featured-image.php',
+	[$dfi, 'add_settings_link']
+);
 // add L10n.
-add_action( 'init', array( $dfi, 'load_plugin_textdomain' ) );
+add_action('init', [$dfi, 'load_plugin_textdomain']);
 // remove setting on removal.
-register_uninstall_hook( __FILE__, array( 'DFI', 'uninstall' ) );
+register_uninstall_hook(__FILE__, ['DFI', 'uninstall']);
 
 /**
  * Exception: https://wordpress.org/plugins/wp-user-frontend/
  *
  * @see https://wordpress.org/support/topic/couldnt-able-to-edit-default-featured-image-from-post/
  */
-add_filter( 'pre_do_shortcode_tag', array( 'DFI_Exceptions', 'wp_user_frontend_pre' ), 9, 2 );
-add_filter( 'do_shortcode_tag', array( 'DFI_Exceptions', 'wp_user_frontend_after' ), 9, 2 );
+add_filter(
+	'pre_do_shortcode_tag',
+	['DFI_Exceptions', 'wp_user_frontend_pre'],
+	9,
+	2
+);
+add_filter(
+	'do_shortcode_tag',
+	['DFI_Exceptions', 'wp_user_frontend_after'],
+	9,
+	2
+);
 
 /**
  * Exception: https://www.wpallimport.com/
  *
  * @see https://wordpress.org/support/topic/importing-images-into-woocommerce-using-cron/
  */
-add_filter( 'dfi_thumbnail_id', array( 'DFI_Exceptions', 'wp_all_import_dfi_workaround' ), 9 );
+add_filter(
+	'dfi_thumbnail_id',
+	['DFI_Exceptions', 'wp_all_import_dfi_workaround'],
+	9
+);
 
 /**
  * Exception: https://wpml.org/
  *
  * @see https://wordpress.org/support/topic/wpml-compatibility-281/
  */
-add_filter( 'dfi_thumbnail_id', array( 'DFI_Exceptions', 'wpml_dont_save_dfi_on_translate' ), 9 );
+add_filter(
+	'dfi_thumbnail_id',
+	['DFI_Exceptions', 'wpml_dont_save_dfi_on_translate'],
+	9
+);


### PR DESCRIPTION
# What is this?
This pull request aims to enhance the functionality of the Default Featured Image plugin for WordPress. It introduces a proof-of-concept feature that uses JavaScript’s `fetch()` function to also apply the set default featured image to images that are set but can’t be loaded (e.g., 404) via HTTP.

> [!IMPORTANT]  
> This is not a production PR but a mere proof of concept.

# Changes

## Code Changes:
1. **In `app/extension-remote-check.php`** and **`set-default-featured-image.php`**:
- The remote check functionality using PHP and JavaScript.
- The `require_once()` statement to load the extension file if it exists.

# Demo
- N/A

# Context
- N/A

**Edit:** I'm sorry for messing up the formatting in `set-default-featured-image`.