### PR TITLE
feat: expose `dfi_image_id` option to REST API

### DIFF
--- a/app/class-dfi.php
+++ b/app/class-dfi.php
@@ -109,23 +109,36 @@ final class DFI {
 		return $null;
 	}
 
+    public function register_media_setting()
+    {
+        register_setting(
+            'media', // settings page.
+            'dfi_image_id', // option name.
+            array(
+                'sanitize_callback' => array( &$this, 'input_validation' ),
+                'show_in_rest' => array(
+                    'schema' => array(
+                        'type' => 'integer',
+                        'minimum' => 1,
+                    )
+                ),
+            )
+        );
+    }
+
 	/**
 	 * Register the setting on the media settings page.
 	 *
 	 * @return void
 	 */
 	public function media_setting() {
-		register_setting(
-			'media', // settings page.
-			'dfi_image_id', // option name.
-			array( &$this, 'input_validation' ) // validation callback.
-		);
+        $this->register_media_setting();
 		add_settings_field(
 			'dfi', // id.
 			_x( 'Default featured image', 'Label on the settings page.', 'default-featured-image' ), // setting title.
 			array( &$this, 'settings_html' ), // display callback.
 			'media', // settings page.
-			'default' // settings section.
+			'default', // settings section.
 		);
 	}
 
@@ -187,7 +200,7 @@ final class DFI {
 			array(
 				'manager_title'  => __( 'Select default featured image', 'default-featured-image' ),
 				'manager_button' => __( 'Set default featured image', 'default-featured-image' ),
-			)
+			),
 		);
 	}
 

--- a/app/class-dfi.php
+++ b/app/class-dfi.php
@@ -109,22 +109,24 @@ final class DFI {
 		return $null;
 	}
 
-    public function register_media_setting()
-    {
-        register_setting(
-            'media', // settings page.
-            'dfi_image_id', // option name.
-            array(
-                'sanitize_callback' => array( &$this, 'input_validation' ),
-                'show_in_rest' => array(
-                    'schema' => array(
-                        'type' => 'integer',
-                        'minimum' => 1,
-                    )
-                ),
-            )
-        );
-    }
+	/**
+	 * Register the DFI option.
+	 */
+	public function register_media_setting() {
+		register_setting(
+			'media', // settings page.
+			'dfi_image_id', // option name.
+			array(
+				'sanitize_callback' => array( &$this, 'input_validation' ),
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'    => 'integer',
+						'minimum' => 1,
+					),
+				),
+			)
+		);
+	}
 
 	/**
 	 * Register the setting on the media settings page.
@@ -132,7 +134,7 @@ final class DFI {
 	 * @return void
 	 */
 	public function media_setting() {
-        $this->register_media_setting();
+		$this->register_media_setting();
 		add_settings_field(
 			'dfi', // id.
 			_x( 'Default featured image', 'Label on the settings page.', 'default-featured-image' ), // setting title.

--- a/set-default-featured-image.php
+++ b/set-default-featured-image.php
@@ -26,6 +26,7 @@ $dfi = DFI::instance();
 
 // add the settings field to the media page.
 add_action( 'admin_init', array( $dfi, 'media_setting' ) );
+add_action( 'rest_api_init', array( $dfi, 'register_media_setting' ) );
 // enqueue the js.
 add_action( 'admin_print_scripts-options-media.php', array( $dfi, 'admin_scripts' ) );
 // get the preview image ajax call.


### PR DESCRIPTION
Hello. We are developing a site management platform and would like to implement support for your plugin. Unfortunately, it is not possible to manage the parameters through the API at the moment. Therefore, I propose this change to expose the parameter and allow it to be read and modified from the outside. 